### PR TITLE
Add Vega-Altair theme to python package

### DIFF
--- a/Python/rwth-colors/RWTHColors/__init__.py
+++ b/Python/rwth-colors/RWTHColors/__init__.py
@@ -1,4 +1,5 @@
 from .cm import ColorManager
+import .altair_theme # type: ignore
 
 from os import listdir
 from os.path import isdir, join

--- a/Python/rwth-colors/RWTHColors/altair_theme.py
+++ b/Python/rwth-colors/RWTHColors/altair_theme.py
@@ -1,0 +1,150 @@
+from RWTHColors import colors as c
+import importlib.util
+
+spec = importlib.util.find_spec("altair")
+
+
+# from RWTHColors/cm.py#rwth_color_cycle
+color_order = [
+    c.RWTHBlau,
+    c.RWTHOrange,
+    c.RWTHGruen,
+    c.RWTHRot,
+    c.RWTHViolett,
+    c.RWTHBordeaux,
+    c.RWTHLila,
+    c.RWTHPetrol,
+    c.RWTHMaiGruen,
+    c.RWTHTuerkis,
+]
+
+# from RWTHColors/mpl-styles/rwth-dark.mplstyle
+color_order_dark = [
+    "#8EBAE5",
+    "#FDD48F",
+    "#B8D698",
+    "#E69679",
+    "#A8859E",
+    "#CD8B87",
+    "#BCB5D7",
+    "#7DA4A7",
+    "#E0E69A",
+    "#89CCCF",
+]
+
+# from https://anthology-of-data.science/posts/altair/better-altair-theme.html
+
+
+def altair_theme_creator(
+    category_palette,
+    sequential_palette,
+    diverging_palette,
+    mark_color="#00549F",
+    axis_color="#000000",
+    font_color="#000000",
+    background_color="#FFFFFF",
+    font="arial",
+    label_font=None,
+    source_font=None,
+    grid_color="#DEDDDD",
+):
+    source_font = source_font or font
+    label_font = label_font or font
+    return {
+        "config": {
+            "title": {
+                "color": font_color
+            },
+            "axisX": {
+                "domainColor": axis_color,
+                "labelFont": font,
+                "tickColor": axis_color,
+                "titleFont": font,
+                "labelColor": font_color,
+                "titleColor": font_color
+            },
+            "axisY": {
+                "gridColor": grid_color,
+                "labelFont": font,
+                "titleFont": font,
+                "labelColor": font_color,
+                "titleColor": font_color
+            },
+            "background": background_color,
+            "legend": {
+                "labelFont": font,
+                "titleFont": font,
+                "labelColor": font_color,
+                "titleColor": font_color
+            },
+            "range": {
+                "category": category_palette,
+                "diverging": diverging_palette,
+                "ordinal": sequential_palette,
+                "ramp": sequential_palette,
+                "heatmap": sequential_palette,
+            },
+            "area": {
+                "fill": mark_color,
+            },
+            "line": {
+                "color": mark_color,
+                "stroke": mark_color,
+            },
+            "trail": {
+                "color": mark_color,
+                "stroke": mark_color,
+            },
+            "path": {
+                "stroke": mark_color,
+            },
+            "text": {
+                "font": source_font,
+                "color": mark_color,
+            },
+            "bar": {
+                "fill": mark_color,
+            },
+        },
+    }
+
+
+if spec is not None:
+    import altair as alt
+
+    @alt.theme.register("rwth", enable=False)
+    def rwth_theme() -> alt.theme.ThemeConfig:
+        return altair_theme_creator(
+            category_palette=[c.HEX[100] for c in color_order],
+            sequential_palette=list(reversed([v for v in c.RWTHBlau.HEX.values()])),
+            diverging_palette=[v for v in c.RWTHRot.HEX.values()]
+            + ["white"]
+            + list(reversed([v for v in c.RWTHBlau.HEX.values()])),
+        )
+
+    @alt.theme.register("rwth-full", enable=False)
+    def rwth_theme_full() -> alt.theme.ThemeConfig:
+        return altair_theme_creator(
+            category_palette=[
+                c.HEX[i] for i in [100, 75, 50, 25, 10] for c in color_order
+            ],
+            sequential_palette=list(reversed([v for v in c.RWTHBlau.HEX.values()])),
+            diverging_palette=[v for v in c.RWTHRot.HEX.values()]
+            + ["white"]
+            + list(reversed([v for v in c.RWTHBlau.HEX.values()])),
+        )
+
+    @alt.theme.register("rwth-dark", enable=False)
+    def rwth_theme_dark() -> alt.theme.ThemeConfig:
+        return altair_theme_creator(
+            category_palette=[c for c in color_order_dark],
+            sequential_palette=['black']+list(c.RWTHBlau.HEX.values()),
+            diverging_palette=[v for v in c.RWTHRot.HEX.values()]
+            + ["white"]
+            + list(reversed([v for v in c.RWTHBlau.HEX.values()])),
+            mark_color=color_order_dark[0],
+            axis_color="#FFFFFF",
+            background_color="#000000",
+            grid_color="#212121",
+            font_color="#FFFFFF"
+        )

--- a/README.md
+++ b/README.md
@@ -139,6 +139,35 @@ This produces:
 
 ![Example Plot](Python/rwth-colors/tests/output/plot.png)
 
+### Vega-Altair plots
+RWTHColors also proveds themes for the plotting library [Vega-Altair](https://altair-viz.github.io/). To activate the themes inlclude the following before using altair:
+
+```python
+import altair as alt
+import RWTHColors.altair_theme
+
+alt.theme.enable("rwth") # or "rwth-full" or "rwth-dark"
+```
+
+The themes `rwth`, `rwth-full` and `rwth-dark`, analog to the matplotlib themes are available. Then you can craete plots as usual, e.g.,:
+
+```python
+import altair as alt
+import pandas as pd
+import RWTHColors.altair_theme
+
+alt.theme.enable("rwth") # or "rwth-full" or "rwth-dark"
+
+source = pd.DataFrame(
+{
+    "a": ["A", "B", "C", "D", "E", "F", "G", "H", "I"],
+    "b": [28, 55, 43, 91, 81, 53, 19, 87, 52],
+}
+)
+
+bar = alt.Chart(source).mark_bar(tooltip=True).encode(x="a:N", y="b:Q").properties(title='Bar Chart')
+
+```
 
 <!-- CONTACT -->
 # Disclaimer

--- a/README.md
+++ b/README.md
@@ -140,11 +140,11 @@ This produces:
 ![Example Plot](Python/rwth-colors/tests/output/plot.png)
 
 ### Vega-Altair plots
-RWTHColors also proveds themes for the plotting library [Vega-Altair](https://altair-viz.github.io/). To activate the themes inlclude the following before using altair:
+RWTHColors also provides themes for the plotting library [Vega-Altair](https://altair-viz.github.io/). To activate the themes inlclude the following before using altair:
 
 ```python
 import altair as alt
-import RWTHColors.altair_theme
+import RWTHColors
 
 alt.theme.enable("rwth") # or "rwth-full" or "rwth-dark"
 ```
@@ -154,7 +154,7 @@ The themes `rwth`, `rwth-full` and `rwth-dark`, analog to the matplotlib themes 
 ```python
 import altair as alt
 import pandas as pd
-import RWTHColors.altair_theme
+import RWTHColors
 
 alt.theme.enable("rwth") # or "rwth-full" or "rwth-dark"
 


### PR DESCRIPTION
I created a theme for the plotting library [Vega-Altair](https://altair-viz.github.io/index.html) based on your matplotlib theme an included it in the python package. The modification doesnt require anyone to install altair but if its installed, it add the themes on the import of RWTHColors. You use it as follows:

```python
import altair as alt
import RWTHColors

alt.theme.enable("rwth") # or "rwth-full" or "rwth-dark"
```

You can see the default altair theme and the rwth themes in the pictures below.

![fig-default](https://github.com/user-attachments/assets/c88f5d78-1a61-428c-8f08-10ed302c05fa)
![fig-rwth](https://github.com/user-attachments/assets/f2d64b61-0c79-4f74-ab05-7ba38333e5c3)
![fig-rwth-full](https://github.com/user-attachments/assets/0c7dc4b0-3b42-4b68-9510-94eb596bf225)
![fig-rwth-dark](https://github.com/user-attachments/assets/594c3a41-71f8-439b-9bf5-5eade147d339)

The images are created with the following code (install the following dependencies: `pip install altair vega_datasets vl-convert-python`

```python
import altair as alt
import numpy as np
from vega_datasets import data
import pandas as pd
import RWTHColors

def plot_graphs(theme=''):
    source = pd.DataFrame(
    {
        "a": ["A", "B", "C", "D", "E", "F", "G", "H", "I"],
        "b": [28, 55, 43, 91, 81, 53, 19, 87, 52],
    }
    )

    bar = alt.Chart(source).mark_bar(tooltip=True).encode(x="a:N", y="b:Q").properties(title='Bar Chart')

    source_stock = data.stocks()

    stacked = alt.Chart(source_stock).mark_line().encode(
        x="date:T",
        y="price:Q",
        color="symbol:N",
        strokeDash="symbol:N",
    ).properties(title='Line Chart')

    source_area = data.iowa_electricity()

    area = alt.Chart(source_area).mark_area().encode(x="year:T", y="net_generation:Q", color="source:N").properties(title='Area Chart')

    x, y = np.meshgrid(range(-5, 5), range(-5, 5))
    z = x**2 + y**2

    source_heat = pd.DataFrame({"x": x.ravel(), "y": y.ravel(), "z": z.ravel()})

    heat = alt.Chart(source_heat).mark_rect().encode(x="x:O", y="y:O", color=alt.Color("z:Q")).properties(title='Heat Map')

    heat_diverging = alt.Chart(source_heat).mark_rect().encode(x="x:O", y="y:O", color=alt.Color("z:Q", scale=alt.Scale(domainMid=30))).properties(title='Heat Map - Diverging')

    return (bar | stacked | area | heat | heat_diverging).properties(title=f'Altair Theme: {theme}')

for x in ['default','rwth','rwth-full','rwth-dark']:
    alt.theme.enable(x)
    f = plot_graphs(x)
    f.save(f"fig-{x}.svg")

```

I could include the code above as a test, but that would require the above packages as a dev dependency. Is this wanted? 